### PR TITLE
EN-4086: Need to set the ID on TermBo's TermSpecificationBo, or else a n...

### DIFF
--- a/rice-middleware/krms/impl/src/main/java/org/kuali/rice/krms/impl/ui/AgendaEditorMaintainable.java
+++ b/rice-middleware/krms/impl/src/main/java/org/kuali/rice/krms/impl/ui/AgendaEditorMaintainable.java
@@ -464,6 +464,7 @@ public class AgendaEditorMaintainable extends MaintainableImpl {
                 newTerm.setDescription(propositionBo.getNewTermDescription());
                 newTerm.setSpecificationId(termSpecId);
                 newTerm.setId(termIdIncrementer.getNewId());
+                newTerm.getSpecification().setId(newTerm.getSpecificationId());
 
                 List<TermParameterBo> params = new ArrayList<TermParameterBo>();
                 for (Map.Entry<String, String> entry : propositionBo.getTermParameters().entrySet()) {


### PR DESCRIPTION
...ew ID will be incorrectly assigned when the TermBo is persisted.

This fixes an issue where creating a new Agenda containing Question
terms (and possibly others) causes the Agenda Editor maint doc to go
into exception routing with this error:

java.sql.SQLIntegrityConstraintViolationException: ORA-01400: cannot
insert NULL into ("KR"."KRMS_TERM_SPEC_T"."NM")