### PR TITLE
Backport of several small KualiCo kc-rice fixes

### DIFF
--- a/rice-framework/krad-service-impl/src/main/java/org/kuali/rice/krad/service/impl/NoteServiceImpl.java
+++ b/rice-framework/krad-service-impl/src/main/java/org/kuali/rice/krad/service/impl/NoteServiceImpl.java
@@ -118,6 +118,7 @@ public class NoteServiceImpl implements NoteService {
     	validateNoteNotNull(note);
     	if ( note.getAttachment() != null ) { // Not sure about this - might blow up when no attachment
     		dataObjectService.delete(note.getAttachment());
+            note.setAttachment(null);
     	}
         dataObjectService.delete(note);
     }

--- a/rice-middleware/krms/framework/src/main/java/org/kuali/rice/krms/framework/engine/expression/ComparisonOperator.java
+++ b/rice-middleware/krms/framework/src/main/java/org/kuali/rice/krms/framework/engine/expression/ComparisonOperator.java
@@ -137,9 +137,9 @@ public enum ComparisonOperator implements Coded {
         } else if (this == LESS_THAN_EQUAL) {
             return result <= 0;
         } else if (this == EXISTS) {
-            return rhs != null;
+            return lhs != null;
         } else if (this == DOES_NOT_EXIST) {
-            return rhs == null;
+            return lhs == null;
         }
         throw new IllegalStateException("Invalid comparison operator detected: " + this);
 	}

--- a/rice-middleware/krms/framework/src/test/java/org/kuali/rice/krms/framework/engine/expression/ComparisonOperatorTest.java
+++ b/rice-middleware/krms/framework/src/test/java/org/kuali/rice/krms/framework/engine/expression/ComparisonOperatorTest.java
@@ -96,15 +96,15 @@ public class ComparisonOperatorTest {
     public void testExists() {
         ComparisonOperator op = ComparisonOperator.fromCode(ComparisonOperator.EXISTS.toString());
         op.setComparisonOperatorService(ComparisonOperatorServiceImpl.getInstance());
-        assertTrue(op.compare("123", "0"));
-        assertFalse(op.compare("123", null));
+        assertTrue(op.compare("123", null));
+        assertFalse(op.compare(null, null));
     }
 
     @Test
     public void testDoesNotExists() {
         ComparisonOperator op = ComparisonOperator.fromCode(ComparisonOperator.DOES_NOT_EXIST.toString());
         op.setComparisonOperatorService(ComparisonOperatorServiceImpl.getInstance());
-        assertFalse(op.compare("123", "0"));
-        assertTrue(op.compare("123", null));
+        assertFalse(op.compare("123", null));
+        assertTrue(op.compare(null, null));
     }
 }

--- a/rice-middleware/krms/impl/src/main/java/org/kuali/rice/krms/impl/repository/PropositionBo.java
+++ b/rice-middleware/krms/impl/src/main/java/org/kuali/rice/krms/impl/repository/PropositionBo.java
@@ -19,6 +19,8 @@ import org.apache.commons.lang.StringUtils;
 import org.kuali.rice.core.api.mo.common.Versioned;
 import org.kuali.rice.krad.data.DataObjectService;
 import org.kuali.rice.krad.data.jpa.PortableSequenceGenerator;
+import org.kuali.rice.krad.data.provider.annotation.SerializationContext;
+import org.kuali.rice.krad.data.provider.annotation.Serialized;
 import org.kuali.rice.krad.service.KRADServiceLocator;
 import org.kuali.rice.krms.api.repository.LogicalOperator;
 import org.kuali.rice.krms.api.repository.proposition.PropositionDefinition;
@@ -126,6 +128,7 @@ public class PropositionBo implements PropositionDefinitionContract, Versioned, 
     private String newTermDescription = "new term " + UUID.randomUUID().toString();
 
     @Transient
+    @Serialized(enabled = true, forContexts= SerializationContext.MAINTENANCE)
     private Map<String, String> termParameters = new HashMap<String, String>();
 
     private void setupParameterDisplayString() {


### PR DESCRIPTION
This includes the following commits from the KualiCo fork of Rice:

JPA error when deleting Notes: https://github.com/kuali/kc-rice/commit/36b67bf75a820a2b41f1e42b1be8a1ee0a0811ee
KRMS Proposition =null and !=null comparisons don't work: https://github.com/kuali/kc-rice/commit/e40f8389dec88fe9e2703105ed302203ab04c4f3
KRMS Agenda Editor term specifications becoming unmapped: https://github.com/kuali/kc-rice/commit/cba19ce67fc5f92d7cf129a58aa4b3315214f65f
KRMS Agenda Editor doesn't save term parameters: https://github.com/kuali/kc-rice/commit/fe575b10e05dfacc4296f8ea4f9e6bf2d1f81978​