### PR TITLE
Backport of several important KRMS fixes from Rice 2.5

### DIFF
--- a/rice-middleware/it/kew/src/test/java/org/kuali/rice/kew/framework/support/krms/KewToRulesEngineIntegrationTest.java
+++ b/rice-middleware/it/kew/src/test/java/org/kuali/rice/kew/framework/support/krms/KewToRulesEngineIntegrationTest.java
@@ -244,7 +244,6 @@ public class KewToRulesEngineIntegrationTest extends KEWTestCase {
         agendaBo.setTypeId(null);
         agendaBo = dataObjectService.save(agendaBo, PersistenceOption.FLUSH);
 
-        agendaBo.setFirstItemId(ruleBo.getId());
         AgendaItemBo agendaItemBo = new AgendaItemBo();
         agendaItemBo.setRule(ruleBo);
         agendaItemBo.setAgendaId(agendaBo.getId());
@@ -254,6 +253,7 @@ public class KewToRulesEngineIntegrationTest extends KEWTestCase {
         agendaItems.add(agendaItemBo);
         agendaBo.setItems(agendaItems);
         agendaBo.setFirstItemId(agendaItemBo.getId());
+        agendaBo.setFirstItem(agendaItemBo);
 
         // also add attribute to the agenda to store event
         Set<AgendaAttributeBo> agendaAttributes = new HashSet<AgendaAttributeBo>();

--- a/rice-middleware/it/krms/src/test/java/org/kuali/rice/krms/impl/ui/AgendaEditorMaintainableIntegrationTest.java
+++ b/rice-middleware/it/krms/src/test/java/org/kuali/rice/krms/impl/ui/AgendaEditorMaintainableIntegrationTest.java
@@ -20,13 +20,17 @@ import org.junit.Test;
 import org.kuali.rice.core.api.resourceloader.GlobalResourceLoader;
 import org.kuali.rice.krad.data.DataObjectService;
 import org.kuali.rice.krms.api.repository.agenda.AgendaDefinition;
+import org.kuali.rice.krms.api.repository.agenda.AgendaItemDefinition;
 import org.kuali.rice.krms.api.repository.context.ContextDefinition;
+import org.kuali.rice.krms.api.repository.proposition.PropositionDefinition;
+import org.kuali.rice.krms.api.repository.rule.RuleDefinition;
 import org.kuali.rice.krms.api.repository.type.KrmsTypeDefinition;
 import org.kuali.rice.krms.impl.repository.ActionBoService;
 import org.kuali.rice.krms.impl.repository.ActionBoServiceImpl;
 import org.kuali.rice.krms.impl.repository.AgendaBo;
 import org.kuali.rice.krms.impl.repository.AgendaBoService;
 import org.kuali.rice.krms.impl.repository.AgendaBoServiceImpl;
+import org.kuali.rice.krms.impl.repository.AgendaItemBo;
 import org.kuali.rice.krms.impl.repository.ContextBoServiceImpl;
 import org.kuali.rice.krms.impl.repository.KrmsRepositoryServiceLocator;
 import org.kuali.rice.krms.impl.repository.PropositionBoService;
@@ -35,27 +39,30 @@ import org.kuali.rice.krms.impl.repository.RuleBoService;
 import org.kuali.rice.krms.impl.repository.RuleBoServiceImpl;
 import org.kuali.rice.krms.impl.repository.TermBoService;
 import org.kuali.rice.krms.impl.repository.TermBoServiceImpl;
-import org.kuali.rice.krms.test.AbstractBoTest;
+import org.kuali.rice.krms.test.AbstractAgendaBoTest;
 import org.kuali.rice.test.BaselineTestCase.BaselineMode;
 import org.kuali.rice.test.BaselineTestCase.Mode;
 
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * Validation Integration Test
  * @author Kuali Rice Team (rice.collab@kuali.org)
  */
 @BaselineMode(Mode.CLEAR_DB)
-public class AgendaEditorMaintainableIntegrationTest extends AbstractBoTest {
+public class AgendaEditorMaintainableIntegrationTest extends AbstractAgendaBoTest {
 
-    static final String NAMESPACE1 = "AEMIT_KRMS_TEST_1";
-    static final String CONTEXT1 = "AEMIT_Context1";
+    static final String NAMESPACEX = "AEMIT_KRMS_TEST_1";
+    static final String CONTEXTX = "AEMIT_Context1";
 
-    static final String CONTEXT1_QUALIFIER = "Context1Qualifier";
-    static final String CONTEXT1_QUALIFIER_VALUE = "BLAH1";
-    static final String AGENDA1 = "TestAgenda1";
+    static final String CONTEXTX_QUALIFIER = "Context1Qualifier";
+    static final String CONTEXTX_QUALIFIER_VALUE = "BLAH1";
+    static final String AGENDAX = "TestAgenda1";
 
     private PropositionBoService propositionBoService;
     private TermBoService termBoService;
@@ -65,6 +72,8 @@ public class AgendaEditorMaintainableIntegrationTest extends AbstractBoTest {
 
     @Before
     public void setup() {
+
+        super.setup();
 
         krmsAttributeDefinitionService = KrmsRepositoryServiceLocator.getKrmsAttributeDefinitionService();
         krmsTypeRepository = KrmsRepositoryServiceLocator.getKrmsTypeRepositoryService();
@@ -91,12 +100,102 @@ public class AgendaEditorMaintainableIntegrationTest extends AbstractBoTest {
 
     @Test
     public void testEmptyAgendaDelete() {
-        ContextDefinition contextDefintion1 = createContextDefinition(NAMESPACE1, CONTEXT1, Collections.singletonMap(
-                CONTEXT1_QUALIFIER, CONTEXT1_QUALIFIER_VALUE));
-        createAgendaDefinition(AGENDA1, "AgendaLabel", contextDefintion1);
-        AgendaDefinition agendaDefinition = agendaBoService.getAgendaByNameAndContextId(AGENDA1, contextDefintion1.getId());
+        ContextDefinition contextDefintion1 = createContextDefinition(NAMESPACEX, CONTEXTX, Collections.singletonMap(
+                CONTEXTX_QUALIFIER, CONTEXTX_QUALIFIER_VALUE));
+        createAgendaDefinition(AGENDAX, "AgendaLabel", contextDefintion1);
+        AgendaDefinition agendaDefinition = agendaBoService.getAgendaByNameAndContextId(AGENDAX,
+                contextDefintion1.getId());
 
         lookupAndSaveDataObject(agendaDefinition);
+    }
+
+    @Test
+    public void testOrphanAgendaItems() {
+        AgendaEditorMaintainable aem = new AgendaEditorMaintainable();
+        AgendaEditor ae = new AgendaEditor();
+        AgendaDefinitionDataWrapper agendaWrapper = new AgendaDefinitionDataWrapper();
+
+        AgendaBo agendaBoToUpdate = findAgendaByPrimaryKey(agendaWrapper.agenda);
+
+        //  Before we change anything, verify everything is as expected
+        AgendaItemDefinition toBeDeletedItem1 = agendaBoService.getAgendaItemById( agendaWrapper.firstItem.getId() );
+        AgendaItemDefinition toBeDeletedItem2 = agendaBoService.getAgendaItemById( agendaWrapper.secondItem.getId() );
+        AgendaItemDefinition toBeDeletedItem3 = agendaBoService.getAgendaItemById( agendaWrapper.thirdItem.getId() );
+        AgendaItemDefinition toBeDeletedItem4 = agendaBoService.getAgendaItemById( agendaWrapper.fourthItem.getId() );
+
+        RuleDefinition toBeDeletedRule1 = ruleBoService.getRuleByRuleId( agendaWrapper.firstItem.getRuleId() );
+        RuleDefinition toBeDeletedRule2 = ruleBoService.getRuleByRuleId( agendaWrapper.secondItem.getRuleId() );
+        RuleDefinition toBeDeletedRule3 = ruleBoService.getRuleByRuleId( agendaWrapper.thirdItem.getRuleId() );
+        RuleDefinition toBeDeletedRule4 = ruleBoService.getRuleByRuleId( agendaWrapper.fourthItem.getRuleId() );
+
+        PropositionDefinition toBeDeletedProp1 = propositionBoService.getPropositionById( agendaWrapper.firstItem.getRule().getPropId() );
+        PropositionDefinition toBeDeletedProp2 = propositionBoService.getPropositionById( agendaWrapper.secondItem.getRule().getPropId() );
+        PropositionDefinition toBeDeletedProp3 = propositionBoService.getPropositionById( agendaWrapper.thirdItem.getRule().getPropId() );
+        PropositionDefinition toBeDeletedProp4 = propositionBoService.getPropositionById( agendaWrapper.fourthItem.getRule().getPropId() );
+
+        assertEquals(agendaBoToUpdate.getItems().size(), 4);
+        assertEquals(agendaBoToUpdate.getName(), "TestAgenda1");
+
+        assertNotNull("First item should be present", toBeDeletedItem1);
+        assertNotNull("Second item should be present", toBeDeletedItem2);
+        assertNotNull("Third item should be present", toBeDeletedItem3);
+        assertNotNull("Fourth item should be present", toBeDeletedItem4);
+
+        assertNotNull("First Item's rule should be present", toBeDeletedRule1);
+        assertNotNull("Second Item's rule should be present", toBeDeletedRule2);
+        assertNotNull("Third Item's rule should be present", toBeDeletedRule3);
+        assertNotNull("Fourth Item's rule should be present", toBeDeletedRule4);
+
+        assertNotNull("First Item's proposition should be present", toBeDeletedProp1);
+        assertNotNull("Second Item's proposition should be present", toBeDeletedProp2);
+        assertNotNull("Third Item's proposition should be present", toBeDeletedProp3);
+        assertNotNull("Fourth Item's proposition should be present", toBeDeletedProp4);
+
+        // Change the agenda!
+        agendaBoToUpdate.setName("Updated Agenda Name!");
+        agendaBoToUpdate.setFirstItem(null);
+        agendaBoToUpdate.setFirstItemId(null);
+        agendaBoToUpdate.setItems(new ArrayList<AgendaItemBo>());
+
+        ae.setAgenda(agendaBoToUpdate);
+        aem.setDataObject(ae);
+        aem.saveDataObject();
+
+        // Get the updated agenda and verify agenda items, rule, propositions, etc were updated or deleted.
+        AgendaBo agendaBoUpdated = findAgendaByPrimaryKey(agendaWrapper.agenda);
+
+        AgendaItemDefinition deletedItem1 = agendaBoService.getAgendaItemById( agendaWrapper.firstItem.getId() );
+        AgendaItemDefinition deletedItem2 = agendaBoService.getAgendaItemById( agendaWrapper.secondItem.getId() );
+        AgendaItemDefinition deletedItem3 = agendaBoService.getAgendaItemById( agendaWrapper.thirdItem.getId() );
+        AgendaItemDefinition deletedItem4 = agendaBoService.getAgendaItemById( agendaWrapper.fourthItem.getId() );
+
+        RuleDefinition deletedRule1 = ruleBoService.getRuleByRuleId( agendaWrapper.firstItem.getRuleId() );
+        RuleDefinition deletedRule2 = ruleBoService.getRuleByRuleId( agendaWrapper.secondItem.getRuleId() );
+        RuleDefinition deletedRule3 = ruleBoService.getRuleByRuleId( agendaWrapper.thirdItem.getRuleId() );
+        RuleDefinition deletedRule4 = ruleBoService.getRuleByRuleId( agendaWrapper.fourthItem.getRuleId() );
+
+        PropositionDefinition deletedProp1 = propositionBoService.getPropositionById( agendaWrapper.firstItem.getRule().getPropId() );
+        PropositionDefinition deletedProp2 = propositionBoService.getPropositionById( agendaWrapper.secondItem.getRule().getPropId() );
+        PropositionDefinition deletedProp3 = propositionBoService.getPropositionById( agendaWrapper.thirdItem.getRule().getPropId() );
+        PropositionDefinition deletedProp4 = propositionBoService.getPropositionById( agendaWrapper.fourthItem.getRule().getPropId() );
+
+        assertEquals(agendaBoUpdated.getItems().size(), 0);
+        assertEquals(agendaBoUpdated.getName(), "Updated Agenda Name!");
+
+        assertNull("First item should be deleted", deletedItem1);
+        assertNull("Second item should be deleted", deletedItem2);
+        assertNull("Third item should be deleted", deletedItem3);
+        assertNull("Fourth item should be deleted", deletedItem4);
+
+        assertNull("First Item's rule should be deleted", deletedRule1);
+        assertNull("Second Item's rule should be deleted", deletedRule2);
+        assertNull("Third Item's rule should be deleted", deletedRule3);
+        assertNull("Fourth Item's rule should be deleted", deletedRule4);
+
+        assertNull("First Item's proposition should be deleted", deletedProp1);
+        assertNull("Second Item's proposition should be deleted", deletedProp2);
+        assertNull("Third Item's proposition should be deleted", deletedProp3);
+        assertNull("Fourth Item's proposition should be deleted", deletedProp4);
     }
 
 /*
@@ -118,34 +217,60 @@ public class AgendaEditorMaintainableIntegrationTest extends AbstractBoTest {
 */
 
     private void lookupAndSaveDataObject(AgendaDefinition agendaDefinition) {
-        AgendaBo blah = findAgendaByPrimaryKey(agendaDefinition);
+        AgendaBo agendaBo = findAgendaByPrimaryKey(agendaDefinition);
 
         AgendaEditorMaintainable aem = new AgendaEditorMaintainable();
         AgendaEditor ae = new AgendaEditor();
-        ae.setAgenda(blah);
+        ae.setAgenda(agendaBo);
         aem.setDataObject(ae);
         aem.saveDataObject();
     }
 
     private AgendaBo findAgendaByPrimaryKey(AgendaDefinition agendaDefinition) {
-        Map<String,String>
-                primaryKeys = new HashMap<String, String>();
         return getDataObjectService().find(AgendaBo.class, agendaDefinition.getId());
     }
 
     private void createAgendaDefinition(String agendaName, String agendaLabel, ContextDefinition contextDefinition) {
-        KrmsTypeDefinition krmsGenericTypeDefinition = createKrmsGenericTypeDefinition(contextDefinition.getNamespace(), "testAgendaTypeService", agendaName, agendaLabel);
+        KrmsTypeDefinition krmsGenericTypeDefinition = createKrmsGenericTypeDefinition(contextDefinition.getNamespace(),
+                "testAgendaTypeService", agendaName, agendaLabel);
 
-        AgendaDefinition agendaDefinition =
-                AgendaDefinition.Builder.create(null, agendaName, krmsGenericTypeDefinition.getId(), contextDefinition.getId()).build();
+        AgendaDefinition agendaDefinition = AgendaDefinition.Builder.create(null, agendaName,
+                krmsGenericTypeDefinition.getId(), contextDefinition.getId()).build();
         agendaDefinition = agendaBoService.createAgenda(agendaDefinition);
         agendaBoService.updateAgenda(agendaDefinition);
 
-        AgendaBo blah = findAgendaByPrimaryKey(agendaDefinition);
+        AgendaBo agendaBo = findAgendaByPrimaryKey(agendaDefinition);
 
-        AgendaDefinition.Builder agendaDefBuilder1 = AgendaDefinition.Builder.create(agendaBoService.to(blah));
+        AgendaDefinition.Builder agendaDefBuilder1 = AgendaDefinition.Builder.create(agendaBoService.to(agendaBo));
         agendaDefinition = agendaDefBuilder1.build();
 
         agendaBoService.updateAgenda(agendaDefinition);
+    }
+
+    private class AgendaDefinitionDataWrapper {
+        private ContextDefinition context;
+        private AgendaDefinition agenda;
+        private AgendaItemDefinition firstItem;
+        private AgendaItemDefinition secondItem;
+        private AgendaItemDefinition thirdItem;
+        private AgendaItemDefinition fourthItem;
+
+        private RuleDefinition firstItemRule;
+
+        AgendaDefinitionDataWrapper() {
+            context = getContextRepository().getContextByNameAndNamespace(CONTEXT1, NAMESPACE1);
+            assertNotNull("context " + CONTEXT1 + " not found", context);
+            agenda = getAgendaBoService().getAgendaByNameAndContextId(AGENDA1, context.getId());
+            assertNotNull("agenda " + AGENDA1 + " not found", agenda);
+
+            firstItem = getAgendaBoService().getAgendaItemById( agenda.getFirstItemId() );
+            assertNotNull("agenda item " + agenda.getFirstItemId() + " not found", firstItem);
+
+            secondItem = firstItem.getAlways();
+            thirdItem = secondItem.getAlways();
+            fourthItem = thirdItem.getAlways();
+
+            firstItemRule = firstItem.getRule();
+        }
     }
 }

--- a/rice-middleware/it/krms/src/test/java/org/kuali/rice/krms/test/AbstractAgendaBoTest.java
+++ b/rice-middleware/it/krms/src/test/java/org/kuali/rice/krms/test/AbstractAgendaBoTest.java
@@ -60,19 +60,19 @@ import java.util.Map;
 public class AbstractAgendaBoTest extends AbstractBoTest {
 
     public static final String CAMPUS_CODE_TERM_NAME = "campusCodeTermSpec";
-    static final String NAMESPACE1 = "KRMS_TEST_1";
-    static final String NAMESPACE2 = "KRMS_TEST_2";
+    protected static final String NAMESPACE1 = "KRMS_TEST_1";
+    protected static final String NAMESPACE2 = "KRMS_TEST_2";
     static final String TSUNAMI_EVENT = "Tsunami";
     static final String EARTHQUAKE_EVENT = "Earthquake";
-    static final String CONTEXT1 = "Context1";
-    static final String CONTEXT2 = "Context2";
+    protected static final String CONTEXT1 = "Context1";
+    protected static final String CONTEXT2 = "Context2";
     static final String CONTEXT3 = "Context3";
     static final String CONTEXT1_QUALIFIER = "Context1Qualifier";
     static final String CONTEXT1_QUALIFIER_VALUE = "BLAH1";
     static final String CONTEXT2_QUALIFIER = "Context2Qualifier";
     static final String CONTEXT2_QUALIFIER_VALUE = "BLAH2";
-    static final String AGENDA1 = "TestAgenda1";
-    static final String AGENDA2 = "Agenda2";
+    protected static final String AGENDA1 = "TestAgenda1";
+    protected static final String AGENDA2 = "Agenda2";
     static final String AGENDA3 = "Agenda3";
     static final String AGENDA4 = "Agenda4";
     static final String AGENDA5 = "Agenda5";
@@ -166,26 +166,40 @@ public class AbstractAgendaBoTest extends AbstractBoTest {
 
         AgendaItemDefinition.Builder agendaItemBuilder1 = AgendaItemDefinition.Builder.create(null, agendaDef.getId());
         agendaItemBuilder1.setRuleId(createRuleDefinition1(contextDefinition, agendaName, nameSpace).getId());
+        agendaItemBuilder1.setRule(RuleDefinition.Builder.create(ruleBoService.getRuleByRuleId(
+                agendaItemBuilder1.getRuleId())));
 
         AgendaItemDefinition.Builder agendaItemBuilder2 = AgendaItemDefinition.Builder.create(null, agendaDef.getId());
         agendaItemBuilder1.setAlways(agendaItemBuilder2);
         agendaItemBuilder2.setRuleId(createRuleDefinition2(contextDefinition, agendaName, nameSpace).getId());
+        agendaItemBuilder2.setRule(RuleDefinition.Builder.create(ruleBoService.getRuleByRuleId(
+                agendaItemBuilder2.getRuleId())));
 
         AgendaItemDefinition.Builder agendaItemBuilder3 = AgendaItemDefinition.Builder.create(null, agendaDef.getId());
         agendaItemBuilder2.setAlways(agendaItemBuilder3);
         agendaItemBuilder3.setRuleId(createRuleDefinition3(contextDefinition, agendaName, nameSpace).getId());
+        agendaItemBuilder3.setRule(RuleDefinition.Builder.create(ruleBoService.getRuleByRuleId(
+                agendaItemBuilder3.getRuleId())));
 
         AgendaItemDefinition.Builder agendaItemBuilder4 = AgendaItemDefinition.Builder.create(null, agendaDef.getId());
         agendaItemBuilder3.setAlways(agendaItemBuilder4);
         agendaItemBuilder4.setRuleId(createRuleDefinition4(contextDefinition, agendaName, nameSpace).getId());
+        agendaItemBuilder4.setRule(RuleDefinition.Builder.create(ruleBoService.getRuleByRuleId(
+                agendaItemBuilder4.getRuleId())));
 
         // String these puppies together.  Kind of a PITA because you need the id from the next item before you insert the previous one
         AgendaItemDefinition agendaItem4 = agendaBoService.createAgendaItem(agendaItemBuilder4.build());
+
         agendaItemBuilder3.setAlwaysId(agendaItem4.getId());
+        agendaItemBuilder3.setAlways(AgendaItemDefinition.Builder.create(agendaItem4));
         AgendaItemDefinition agendaItem3 = agendaBoService.createAgendaItem(agendaItemBuilder3.build());
+
         agendaItemBuilder2.setAlwaysId(agendaItem3.getId());
+        agendaItemBuilder2.setAlways(AgendaItemDefinition.Builder.create(agendaItem3));
         AgendaItemDefinition agendaItem2 = agendaBoService.createAgendaItem(agendaItemBuilder2.build());
+
         agendaItemBuilder1.setAlwaysId(agendaItem2.getId());
+        agendaItemBuilder1.setAlways(AgendaItemDefinition.Builder.create(agendaItem2));
         AgendaItemDefinition agendaItem1 = agendaBoService.createAgendaItem(agendaItemBuilder1.build());
 
         AgendaDefinition.Builder agendaDefBuilder1 = AgendaDefinition.Builder.create(agendaDef);

--- a/rice-middleware/it/krms/src/test/java/org/kuali/rice/krms/test/ValidationIntegrationTest.java
+++ b/rice-middleware/it/krms/src/test/java/org/kuali/rice/krms/test/ValidationIntegrationTest.java
@@ -610,7 +610,6 @@ public class ValidationIntegrationTest extends AbstractBoTest {
         agendaBo.setTypeId(null);
         agendaBo = getDataObjectService().save(agendaBo, PersistenceOption.FLUSH);
 
-        agendaBo.setFirstItemId(ruleBo.getId());
         AgendaItemBo agendaItemBo = new AgendaItemBo();
         agendaItemBo.setRule(ruleBo);
         agendaItemBo.setAgendaId(agendaBo.getId());
@@ -620,6 +619,7 @@ public class ValidationIntegrationTest extends AbstractBoTest {
         agendaItems.add(agendaItemBo);
         agendaBo.setItems(agendaItems);
         agendaBo.setFirstItemId(agendaItemBo.getId());
+        agendaBo.setFirstItem(agendaItemBo);
 
         // also add attribute to the agenda to store event
         Set<AgendaAttributeBo> agendaAttributes = new HashSet<AgendaAttributeBo>();

--- a/rice-middleware/krms/api/src/main/java/org/kuali/rice/krms/api/repository/agenda/AgendaItemDefinition.java
+++ b/rice-middleware/krms/api/src/main/java/org/kuali/rice/krms/api/repository/agenda/AgendaItemDefinition.java
@@ -233,6 +233,7 @@ public final class AgendaItemDefinition extends AbstractDataTransferObject imple
         private Builder(String id, String agendaId) {
         	setId(id);
         	setAgendaId(agendaId);
+			setVersionNumber(0L);
         }
 
         /**

--- a/rice-middleware/krms/api/src/main/java/org/kuali/rice/krms/api/repository/proposition/PropositionParameter.java
+++ b/rice-middleware/krms/api/src/main/java/org/kuali/rice/krms/api/repository/proposition/PropositionParameter.java
@@ -64,7 +64,7 @@ public final class PropositionParameter extends AbstractDataTransferObject imple
 	@XmlElement(name = Elements.SEQUENCE, required=true)
 	private Integer sequenceNumber;
     @XmlElement(name = CoreConstants.CommonElements.VERSION_NUMBER, required = false)
-    private final Long versionNumber;
+	private Long versionNumber;
     @XmlElement(name = Elements.TERM_VALUE, required=false)
     private TermDefinition termValue;
 

--- a/rice-middleware/krms/api/src/test/groovy/org/kuali/rice/krms/api/repository/AgendaDefinitionTest.groovy
+++ b/rice-middleware/krms/api/src/test/groovy/org/kuali/rice/krms/api/repository/AgendaDefinitionTest.groovy
@@ -167,7 +167,7 @@ class AgendaDefinitionTest {
 	}
 
 	@Test
-	public void testXmlUnmarshal_small_AgendaDefinition() {
+	public void mlUnmarshal_small_AgendaDefinition() {
 	  JAXBContext jc = JAXBContext.newInstance(AgendaDefinition.class)
 	  Unmarshaller unmarshaller = jc.createUnmarshaller()
 	  AgendaDefinition myAgenda = (AgendaDefinition) unmarshaller.unmarshal(new StringReader(SMALL_AGENDA))

--- a/rice-middleware/krms/impl/src/main/java/org/kuali/rice/krms/impl/repository/ActionBo.java
+++ b/rice-middleware/krms/impl/src/main/java/org/kuali/rice/krms/impl/repository/ActionBo.java
@@ -81,8 +81,7 @@ public class ActionBo implements ActionDefinitionContract, Versioned, Serializab
     @Version
     private Long versionNumber;
 
-    @OneToMany(orphanRemoval = true, mappedBy = "action",
-            cascade = { CascadeType.MERGE, CascadeType.REMOVE, CascadeType.PERSIST })
+    @OneToMany(mappedBy = "action", cascade = { CascadeType.REFRESH, CascadeType.MERGE, CascadeType.REMOVE, CascadeType.PERSIST })
     private List<ActionAttributeBo> attributeBos;
 
     @Override

--- a/rice-middleware/krms/impl/src/main/java/org/kuali/rice/krms/impl/repository/AgendaBo.java
+++ b/rice-middleware/krms/impl/src/main/java/org/kuali/rice/krms/impl/repository/AgendaBo.java
@@ -70,14 +70,18 @@ public class AgendaBo implements AgendaDefinitionContract, Serializable {
     @Convert(converter = BooleanYNConverter.class)
     private boolean active = true;
 
-    @Column(name = "INIT_AGENDA_ITM_ID")
+    @Column(name = "INIT_AGENDA_ITM_ID", insertable = false, updatable = false)
     private String firstItemId;
+
+    @ManyToOne(targetEntity = AgendaItemBo.class, cascade = { CascadeType.REFRESH, CascadeType.REMOVE, CascadeType.MERGE, CascadeType.PERSIST })
+    @JoinColumn(name = "INIT_AGENDA_ITM_ID")
+    private AgendaItemBo firstItem;
 
     @Column(name = "VER_NBR")
     @Version
     private Long versionNumber;
 
-    @OneToMany(orphanRemoval = true, mappedBy = "agenda", cascade = { CascadeType.REFRESH, CascadeType.REMOVE, CascadeType.PERSIST })
+    @OneToMany(orphanRemoval = true, mappedBy = "agenda", cascade = { CascadeType.REFRESH})
     @JoinColumn(name = "AGENDA_ID", referencedColumnName = "AGENDA_ID", insertable = true, updatable = true)
     private Set<AgendaAttributeBo> attributeBos;
 
@@ -160,6 +164,7 @@ public class AgendaBo implements AgendaDefinitionContract, Serializable {
 
                 if (initAgendaItemId != null && initAgendaItemId.equals(agendaItem.getId())) {
                     copiedAgenda.setFirstItemId(copiedAgendaItem.getId());
+                    copiedAgenda.setFirstItem(copiedAgendaItem);
                 }
 
                 copiedAgendaItems.add(copiedAgendaItem);
@@ -236,6 +241,18 @@ public class AgendaBo implements AgendaDefinitionContract, Serializable {
 
     public void setFirstItemId(String firstItemId) {
         this.firstItemId = firstItemId;
+    }
+
+    public AgendaItemBo getFirstItem() {
+        return firstItem;
+    }
+
+    public void setFirstItem(AgendaItemBo firstItem) {
+        this.firstItem = firstItem;
+
+        if (firstItem != null) {
+            firstItemId = firstItem.getId();
+        }
     }
 
     public Set<AgendaAttributeBo> getAttributeBos() {

--- a/rice-middleware/krms/impl/src/main/java/org/kuali/rice/krms/impl/repository/AgendaBoServiceImpl.java
+++ b/rice-middleware/krms/impl/src/main/java/org/kuali/rice/krms/impl/repository/AgendaBoServiceImpl.java
@@ -124,6 +124,9 @@ public final class AgendaBoServiceImpl implements AgendaBoService {
 
         // move over AgendaBo members that don't get populated from AgendaDefinition
         boToUpdate.setItems(existing.getItems());
+        if (StringUtils.isNotBlank(agenda.getFirstItemId())) {
+            boToUpdate.setFirstItem(dataObjectService.find(AgendaItemBo.class, agenda.getFirstItemId()));
+        }
 
         // delete any old, existing attributes
         Map<String,String> fields = new HashMap<String,String>(1);
@@ -211,6 +214,22 @@ public final class AgendaBoServiceImpl implements AgendaBoService {
         }
 
         AgendaItemBo bo = AgendaItemBo.from(agendaItem);
+        if (StringUtils.isNotBlank(agendaItem.getRuleId()) && agendaItem.getRule() == null ) {
+            bo.setRule(dataObjectService.find(RuleBo.class, agendaItem.getRuleId()));
+        }
+
+        if (StringUtils.isNotBlank(agendaItem.getAlwaysId()) && agendaItem.getAlways() == null ) {
+            bo.setAlways(dataObjectService.find(AgendaItemBo.class, agendaItem.getAlwaysId()));
+        }
+
+        if (StringUtils.isNotBlank(agendaItem.getWhenTrueId()) && agendaItem.getWhenTrue() == null ) {
+            bo.setWhenTrue(dataObjectService.find(AgendaItemBo.class, agendaItem.getWhenTrueId()));
+        }
+
+        if (StringUtils.isNotBlank(agendaItem.getWhenFalseId()) && agendaItem.getWhenFalse() == null ) {
+            bo.setWhenFalse(dataObjectService.find(AgendaItemBo.class, agendaItem.getWhenFalseId()));
+        }
+
         bo = dataObjectService.save(bo, PersistenceOption.FLUSH);
         return AgendaItemBo.to(bo);
     }

--- a/rice-middleware/krms/impl/src/main/java/org/kuali/rice/krms/impl/repository/AgendaItemBo.java
+++ b/rice-middleware/krms/impl/src/main/java/org/kuali/rice/krms/impl/repository/AgendaItemBo.java
@@ -17,6 +17,7 @@ package org.kuali.rice.krms.impl.repository;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
+import org.eclipse.persistence.annotations.OptimisticLocking;
 import org.kuali.rice.core.api.mo.common.Versioned;
 import org.kuali.rice.core.api.util.io.SerializationUtils;
 import org.kuali.rice.krad.data.jpa.PortableSequenceGenerator;
@@ -48,6 +49,7 @@ import java.util.Map;
  */
 @Entity
 @Table(name = "KRMS_AGENDA_ITM_T")
+@OptimisticLocking(cascade = true)
 public class AgendaItemBo implements AgendaItemDefinitionContract, Versioned, Serializable {
 
     private static final long serialVersionUID = 1L;
@@ -66,39 +68,36 @@ public class AgendaItemBo implements AgendaItemDefinitionContract, Versioned, Se
     @Column(name = "AGENDA_ID")
     private String agendaId;
 
-    @Column(name = "RULE_ID")
-    private String ruleId;
-
     @Column(name = "SUB_AGENDA_ID")
     private String subAgendaId;
 
-    @Column(name = "WHEN_TRUE")
+    @Column(name = "WHEN_TRUE", insertable = false, updatable = false)
     private String whenTrueId;
 
-    @Column(name = "WHEN_FALSE")
+    @Column(name = "WHEN_FALSE", insertable = false, updatable = false)
     private String whenFalseId;
 
-    @Column(name = "ALWAYS")
+    @Column(name = "ALWAYS", insertable = false, updatable = false)
     private String alwaysId;
 
-    @ManyToOne(targetEntity = RuleBo.class, fetch = FetchType.LAZY, cascade = { CascadeType.REFRESH })
-    @JoinColumn(name = "RULE_ID", referencedColumnName = "RULE_ID", insertable = false, updatable = false)
+    @ManyToOne(targetEntity = RuleBo.class, fetch = FetchType.LAZY, cascade = { CascadeType.REFRESH, CascadeType.MERGE, CascadeType.REMOVE, CascadeType.PERSIST})
+    @JoinColumn(name = "RULE_ID", referencedColumnName = "RULE_ID")
     private RuleBo rule;
 
     @Column(name = "VER_NBR")
     @Version
     private Long versionNumber;
 
-    @ManyToOne(targetEntity = AgendaItemBo.class, cascade = { CascadeType.REFRESH })
-    @JoinColumn(name = "WHEN_TRUE", referencedColumnName = "AGENDA_ITM_ID", insertable = false, updatable = false)
+    @ManyToOne(targetEntity = AgendaItemBo.class, cascade = { CascadeType.REFRESH, CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REMOVE })
+    @JoinColumn(name = "WHEN_TRUE", referencedColumnName = "AGENDA_ITM_ID")
     private AgendaItemBo whenTrue;
 
-    @ManyToOne(targetEntity = AgendaItemBo.class, cascade = { CascadeType.REFRESH })
-    @JoinColumn(name = "WHEN_FALSE", referencedColumnName = "AGENDA_ITM_ID", insertable = false, updatable = false)
+    @ManyToOne(targetEntity = AgendaItemBo.class, cascade = { CascadeType.REFRESH, CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REMOVE })
+    @JoinColumn(name = "WHEN_FALSE", referencedColumnName = "AGENDA_ITM_ID")
     private AgendaItemBo whenFalse;
 
-    @ManyToOne(targetEntity = AgendaItemBo.class, cascade = { CascadeType.REFRESH })
-    @JoinColumn(name = "ALWAYS", referencedColumnName = "AGENDA_ITM_ID", insertable = false, updatable = false)
+    @ManyToOne(targetEntity = AgendaItemBo.class, cascade = { CascadeType.REFRESH, CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REMOVE })
+    @JoinColumn(name = "ALWAYS", referencedColumnName = "AGENDA_ITM_ID")
     private AgendaItemBo always;
 
     public String getUl(AgendaItemBo firstItem) {
@@ -107,7 +106,7 @@ public class AgendaItemBo implements AgendaItemDefinitionContract, Versioned, Se
 
     public String getUlHelper(AgendaItemBo item) {
         StringBuilder sb = new StringBuilder();
-        sb.append("<li>" + ruleId + "</li>");
+        sb.append("<li>" + getRuleId() + "</li>");
 
         if (whenTrue != null) {
             sb.append("<ul><li>when true</li><ul>");
@@ -204,15 +203,13 @@ public class AgendaItemBo implements AgendaItemDefinitionContract, Versioned, Se
     /**
      * @return the ruleId
      */
+    @Override
     public String getRuleId() {
-        return this.ruleId;
-    }
+        if (rule != null) {
+            return rule.getId();
+        }
 
-    /**
-     * @param ruleId the ruleId to set
-     */
-    public void setRuleId(String ruleId) {
-        this.ruleId = ruleId;
+        return null;
     }
 
     /**
@@ -355,11 +352,6 @@ public class AgendaItemBo implements AgendaItemDefinitionContract, Versioned, Se
      */
     public void setRule(RuleBo rule) {
         this.rule = rule;
-        if (rule != null) {
-            setRuleId(rule.getId());
-        } else {
-            setRuleId(null);
-        }
     }
 
     /**
@@ -382,7 +374,7 @@ public class AgendaItemBo implements AgendaItemDefinitionContract, Versioned, Se
      * @param im immutable object
      * @return the mutable bo
      */
-    static AgendaItemBo from(AgendaItemDefinition im) {
+    public static AgendaItemBo from(AgendaItemDefinition im) {
         if (im == null) {
             return null;
         }
@@ -390,7 +382,6 @@ public class AgendaItemBo implements AgendaItemDefinitionContract, Versioned, Se
         AgendaItemBo bo = new AgendaItemBo();
         bo.id = im.getId();
         bo.agendaId = im.getAgendaId();
-        bo.ruleId = im.getRuleId();
         bo.subAgendaId = im.getSubAgendaId();
         bo.whenTrueId = im.getWhenTrueId();
         bo.whenFalseId = im.getWhenFalseId();

--- a/rice-middleware/krms/impl/src/main/java/org/kuali/rice/krms/impl/repository/KrmsRepositoryServiceLocator.java
+++ b/rice-middleware/krms/impl/src/main/java/org/kuali/rice/krms/impl/repository/KrmsRepositoryServiceLocator.java
@@ -49,6 +49,7 @@ public final class KrmsRepositoryServiceLocator {
     public static final String KRMS_AGENDA_AUTHORIZATION_SERVICE = "agendaAuthorizationService";
     public static final String KRMS_REPOSITORY_TO_ENGINE_TRANSLATOR = "repositoryToEngineTranslator";
     public static final String TYPE_TYPE_RELATION_BO_SERVICE = "typeTypeRelationBoService";
+    public static final String KRMS_PROPOSITION_BO_SERVICE = "propositionBoService";
 
 	private static KrmsAttributeDefinitionService krmsAttributeDefinitionService;
     private static ContextBoService contextBoService;
@@ -60,6 +61,7 @@ public final class KrmsRepositoryServiceLocator {
     private static KrmsTypeRepositoryService krmsTypeRepositoryService;
     private static RepositoryToEngineTranslator krmsRepositoryToEngineTranslator;
     private static TypeTypeRelationBoService typeTypeRelationBoService;
+    private static PropositionBoService propositionBoService;
 
     public static <T extends Object> T getService(String serviceName) {
 		return KrmsRepositoryServiceLocator.<T>getBean(serviceName);
@@ -148,5 +150,12 @@ public final class KrmsRepositoryServiceLocator {
             typeTypeRelationBoService = getService(TYPE_TYPE_RELATION_BO_SERVICE);
         }
         return typeTypeRelationBoService;
+    }
+
+    public static PropositionBoService getPropositionBoService() {
+        if (propositionBoService == null) {
+            propositionBoService = getService(KRMS_PROPOSITION_BO_SERVICE);
+        }
+        return propositionBoService;
     }
 }

--- a/rice-middleware/krms/impl/src/main/java/org/kuali/rice/krms/impl/repository/PropositionBo.java
+++ b/rice-middleware/krms/impl/src/main/java/org/kuali/rice/krms/impl/repository/PropositionBo.java
@@ -16,6 +16,7 @@
 package org.kuali.rice.krms.impl.repository;
 
 import org.apache.commons.lang.StringUtils;
+import org.eclipse.persistence.annotations.PrivateOwned;
 import org.kuali.rice.core.api.mo.common.Versioned;
 import org.kuali.rice.krad.data.DataObjectService;
 import org.kuali.rice.krad.data.jpa.PortableSequenceGenerator;
@@ -38,17 +39,14 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
-import javax.persistence.ManyToMany;
 import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
 import javax.persistence.Table;
 import javax.persistence.Transient;
-import javax.persistence.Version;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -82,7 +80,8 @@ public class PropositionBo implements PropositionDefinitionContract, Versioned, 
     @Column(name = "DSCRM_TYP_CD")
     private String propositionTypeCode;
 
-    @OneToMany(orphanRemoval = true, cascade = CascadeType.ALL, mappedBy = "proposition")
+    @OneToMany(mappedBy = "proposition", cascade = { CascadeType.REFRESH, CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REMOVE })
+    @PrivateOwned
     @OrderBy("sequenceNumber")
     private List<PropositionParameterBo> parameters = new ArrayList<PropositionParameterBo>();
 
@@ -93,10 +92,9 @@ public class PropositionBo implements PropositionDefinitionContract, Versioned, 
     private Integer compoundSequenceNumber;
 
     @Column(name = "VER_NBR")
-    @Version
     private Long versionNumber;
 
-    @ManyToMany(targetEntity = PropositionBo.class, cascade = { CascadeType.REFRESH, CascadeType.REMOVE, CascadeType.PERSIST })
+    @OneToMany(targetEntity = PropositionBo.class, cascade = { CascadeType.REFRESH, CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REMOVE})
     @JoinTable(name = "KRMS_CMPND_PROP_PROPS_T", joinColumns = { @JoinColumn(name = "CMPND_PROP_ID", referencedColumnName = "PROP_ID") }, inverseJoinColumns = { @JoinColumn(name = "PROP_ID", referencedColumnName = "PROP_ID") })
     @OrderBy("compoundSequenceNumber")
     private List<PropositionBo> compoundComponents;
@@ -292,7 +290,7 @@ public class PropositionBo implements PropositionDefinitionContract, Versioned, 
 
         // we don't set rule here, it is set in RuleBo.from
 
-        setRuleIdRecursive(im.getRuleId(), bo);
+        bo.setRuleId(im.getRuleId());
 
         bo.typeId = im.getTypeId();
         bo.propositionTypeCode = im.getPropositionTypeCode();
@@ -312,21 +310,13 @@ public class PropositionBo implements PropositionDefinitionContract, Versioned, 
             bo.compoundComponents.add(PropositionBo.from(prop));
         }
 
-        bo.setVersionNumber(im.getVersionNumber());
+        if (im.getVersionNumber() == null) {
+            bo.setVersionNumber(0l);
+        } else {
+            bo.setVersionNumber(im.getVersionNumber());
+        }
 
         return bo;
-    }
-
-    private static void setRuleIdRecursive(String ruleId, PropositionBo prop) {
-        prop.ruleId = ruleId;
-
-        if (prop.compoundComponents != null) {
-            for (PropositionBo child : prop.compoundComponents) {
-                if (child != null) {
-                    setRuleIdRecursive(ruleId, child);
-                }
-            }
-        }
     }
 
     /**
@@ -381,7 +371,11 @@ public class PropositionBo implements PropositionDefinitionContract, Versioned, 
             pConst.setSequenceNumber(new Integer("1"));
             pConst.setVersionNumber(new Long(1));
             pConst.setValue("");
-            List<PropositionParameterBo> paramList = Arrays.asList(pTerm, pConst, pOp);
+
+            List<PropositionParameterBo> paramList = new ArrayList<PropositionParameterBo>(3);
+            paramList.add(pTerm);
+            paramList.add(pConst);
+            paramList.add(pOp);
 
             prop.setParameters(paramList);
         }
@@ -464,7 +458,7 @@ public class PropositionBo implements PropositionDefinitionContract, Versioned, 
         List<PropositionBo> newCompoundComponents = new ArrayList<PropositionBo>();
         for (PropositionBo component : existing.getCompoundComponents()) {
             PropositionBo newComponent = copyProposition(component);
-            ((ArrayList<PropositionBo>) newCompoundComponents).add(component);
+            ((ArrayList<PropositionBo>) newCompoundComponents).add(newComponent);
         }
 
         newProp.setCompoundComponents(newCompoundComponents);
@@ -535,8 +529,17 @@ public class PropositionBo implements PropositionDefinitionContract, Versioned, 
         return ruleId;
     }
 
+    /**
+    * Sets the ruleId on this proposition and all its compound components.
+    *
+    * @param ruleId the ruleId to set
+    */
     public void setRuleId(String ruleId) {
         this.ruleId = ruleId;
+
+        if (getCompoundComponents() != null) for (PropositionBo child : getCompoundComponents()) {
+            child.setRuleId(ruleId);
+        }
     }
 
     public String getTypeId() {

--- a/rice-middleware/krms/impl/src/main/java/org/kuali/rice/krms/impl/repository/PropositionParameterBo.java
+++ b/rice-middleware/krms/impl/src/main/java/org/kuali/rice/krms/impl/repository/PropositionParameterBo.java
@@ -66,7 +66,7 @@ public class PropositionParameterBo implements PropositionParameterContract, Ser
 
     @Column(name = "VER_NBR")
     @Version
-    private Long versionNumber;
+    private Long versionNumber = 0l;
 
     public TermDefinition getTermValue() {
         return termValue;

--- a/rice-middleware/krms/impl/src/main/java/org/kuali/rice/krms/impl/repository/RuleBo.java
+++ b/rice-middleware/krms/impl/src/main/java/org/kuali/rice/krms/impl/repository/RuleBo.java
@@ -16,6 +16,7 @@
 package org.kuali.rice.krms.impl.repository;
 
 import org.apache.commons.lang.StringUtils;
+import org.eclipse.persistence.annotations.OptimisticLocking;
 import org.kuali.rice.core.api.mo.common.Versioned;
 import org.kuali.rice.core.api.util.tree.Node;
 import org.kuali.rice.core.api.util.tree.Tree;
@@ -58,6 +59,7 @@ import java.util.Map;
 
 @Entity
 @Table(name = "KRMS_RULE_T")
+@OptimisticLocking(cascade = true)
 public class RuleBo implements RuleDefinitionContract, Versioned, Serializable {
 
     private static final long serialVersionUID = 1L;
@@ -94,16 +96,15 @@ public class RuleBo implements RuleDefinitionContract, Versioned, Serializable {
     @Version
     private Long versionNumber;
 
-    @ManyToOne(targetEntity = PropositionBo.class, fetch = FetchType.LAZY, cascade = { CascadeType.REFRESH, CascadeType.REMOVE, CascadeType.PERSIST })
-    @JoinColumn(name = "PROP_ID", referencedColumnName = "PROP_ID", insertable = true, updatable = true)
+    @ManyToOne(targetEntity = PropositionBo.class, fetch = FetchType.LAZY, cascade = { CascadeType.REFRESH, CascadeType.MERGE, CascadeType.REMOVE, CascadeType.PERSIST })
+    @JoinColumn(name = "PROP_ID", referencedColumnName = "PROP_ID")
     private PropositionBo proposition;
 
-    @OneToMany(mappedBy = "rule",
-            cascade = { CascadeType.MERGE, CascadeType.REMOVE, CascadeType.PERSIST })
+    @OneToMany(mappedBy = "rule", cascade = { CascadeType.REFRESH, CascadeType.MERGE, CascadeType.REMOVE, CascadeType.PERSIST })
     private List<ActionBo> actions;
 
-    @OneToMany(targetEntity = RuleAttributeBo.class, fetch = FetchType.LAZY, orphanRemoval = true, cascade = { CascadeType.REFRESH, CascadeType.REMOVE, CascadeType.PERSIST })
-    @JoinColumn(name = "RULE_ID", referencedColumnName = "RULE_ID", insertable = true, updatable = true)
+    @OneToMany(targetEntity = RuleAttributeBo.class, fetch = FetchType.LAZY, cascade = { CascadeType.REFRESH, CascadeType.MERGE, CascadeType.REMOVE, CascadeType.PERSIST })
+    @JoinColumn(name = "RULE_ID", referencedColumnName = "RULE_ID")
     private List<RuleAttributeBo> attributeBos;
 
     @Transient
@@ -392,7 +393,7 @@ public class RuleBo implements RuleDefinitionContract, Versioned, Serializable {
     }
 
     public static RuleBo copyRule(RuleBo existing) {
-        // create a simple proposition Bo  
+        // create a rule Bo
         RuleBo newRule = new RuleBo();
         // copy simple fields  
         newRule.setId(ruleIdIncrementer.getNewId());

--- a/rice-middleware/krms/impl/src/main/java/org/kuali/rice/krms/impl/ui/AgendaEditor.java
+++ b/rice-middleware/krms/impl/src/main/java/org/kuali/rice/krms/impl/ui/AgendaEditor.java
@@ -23,6 +23,7 @@ import org.kuali.rice.krms.impl.repository.AgendaItemBo;
 import org.kuali.rice.krms.impl.repository.ContextBo;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +48,8 @@ public class AgendaEditor implements Serializable {
     private String cutAgendaItemId;
     private String selectedPropositionId;
     private String cutPropositionId;
+    private List<String> deletedPropositionIdsFromRule = new ArrayList<String>();
+    private List<String> deletedPropositionIds = new ArrayList<String>();
     private String copyRuleName;
     private String oldContextId;
     private String ruleEditorMessage;
@@ -271,6 +274,67 @@ public class AgendaEditor implements Serializable {
      */
     public String getCutPropositionId() {
         return cutPropositionId;
+    }
+
+    /**
+     * A list of the IDs for the propositions that have been deleted from this rule.
+     *
+     * @return the deleted proposition IDs
+     */
+    public List<String> getDeletedPropositionIdsFromRule() {
+        return deletedPropositionIdsFromRule;
+    }
+
+    /**
+     * Set the list of the IDs for the propositions that have been deleted from this rule.
+     *
+     * @param deletedPropositionIdsFromRule the proposition IDs to set
+     */
+    public void setDeletedPropositionIdsFromRule(List<String> deletedPropositionIdsFromRule) {
+        this.deletedPropositionIdsFromRule = deletedPropositionIdsFromRule;
+    }
+
+    /**
+     * Get the list of the IDs for propositions that have been deleted from this agenda.
+     *
+     * @return the deleted proposition IDs
+     */
+    public List<String> getDeletedPropositionIds() {
+        return deletedPropositionIds;
+    }
+
+    /**
+     * Set the list of the IDs for propositions that have been deleted from this agenda.
+     *
+     * @param deletedPropositionIds the proposition IDs to set
+     */
+    public void setDeletedPropositionIds(List<String> deletedPropositionIds) {
+        this.deletedPropositionIds = deletedPropositionIds;
+    }
+
+    public void addDeletedPropositionIdFromRule(String propId) {
+        getDeletedPropositionIdsFromRule().add(propId);
+    }
+
+    /**
+     * Removes all of the proposition ID that have been tracked as deleted from this rule.
+     *
+     * <p>This is something to do when the user abandons the changes that have been made to
+     * the current edited rule.</p>
+     */
+    public void clearDeletedPropositionIdsFromRule() {
+        getDeletedPropositionIdsFromRule().clear();
+    }
+
+    /**
+     * Moves all of the proposition IDs that have been tracked as deleted from this rule to
+     * the list on the agenda.
+     *
+     * <p>This essentially commits to the deletions that have been made in the rule.</p>
+     */
+    public void applyDeletedPropositionIdsFromRule() {
+        getDeletedPropositionIds().addAll(getDeletedPropositionIdsFromRule());
+        clearDeletedPropositionIdsFromRule();
     }
 
     public String getContextName() {

--- a/rice-middleware/krms/impl/src/main/java/org/kuali/rice/krms/impl/ui/AgendaEditorController.java
+++ b/rice-middleware/krms/impl/src/main/java/org/kuali/rice/krms/impl/ui/AgendaEditorController.java
@@ -262,6 +262,9 @@ public class AgendaEditorController extends MaintenanceDocumentController {
         AgendaEditor agendaEditor = getAgendaEditor(form);
         AgendaEditorBusRule rule = new AgendaEditorBusRule();
 
+        // clear the deleted list for the previous edited rule before editing another one
+        agendaEditor.clearDeletedPropositionIdsFromRule();
+
         if (rule.validContext(agendaEditor) && rule.validAgendaName(agendaEditor)) {
             agendaEditor.setAddRuleInProgress(false);
             // this is the root of the tree:
@@ -365,6 +368,7 @@ public class AgendaEditorController extends MaintenanceDocumentController {
             newAgendaItem.setAgendaId(getCreateAgendaId(agenda));
 
             if (agenda.getFirstItemId() == null) {
+                agenda.setFirstItem(newAgendaItem);
                 agenda.setFirstItemId(newAgendaItem.getId());
             } else {
                 // insert agenda in tree
@@ -451,8 +455,20 @@ public class AgendaEditorController extends MaintenanceDocumentController {
      * @return true if the proposition is considered valid
      */
     private boolean validateSimpleProposition(PropositionBo proposition, String namespace) {
-        boolean result = true; 
-        
+        boolean result = true;
+
+        if (!CollectionUtils.isEmpty(proposition.getCompoundComponents())) {
+            GlobalVariables.getMessageMap().putError(KRMSPropertyConstants.Rule.PROPOSITION_TREE_GROUP_ID,
+                    "error.rule.proposition.simple.hasChildren", proposition.getDescription());
+            result &= false; // simple prop should not have compound components
+        }
+
+        if (CollectionUtils.isEmpty(proposition.getParameters())) {
+            result &= false;
+
+            return result;
+        }
+
         String propConstant = null;
         if (proposition.getParameters().get(1) != null) {
             propConstant = proposition.getParameters().get(1).getValue();
@@ -480,6 +496,9 @@ public class AgendaEditorController extends MaintenanceDocumentController {
             GlobalVariables.getMessageMap().putErrorWithoutFullErrorPath(KRMSPropertyConstants.Rule.PROPOSITION_TREE_GROUP_ID,
                     "error.rule.proposition.simple.blankField", proposition.getDescription(), "Operator");
             result &= false;
+
+            // The remaining checks depend on a non-blank operator, so we'll short circuit to avoid possible NPEs
+            return result;
         }
 
         if (StringUtils.isBlank(propConstant) && !operatorCode.endsWith("null")) { // ==null and !=null operators have blank values.
@@ -516,12 +535,6 @@ public class AgendaEditorController extends MaintenanceDocumentController {
                     }
                 }
             }
-        }
-
-        if (!CollectionUtils.isEmpty(proposition.getCompoundComponents())) {
-            GlobalVariables.getMessageMap().putError(KRMSPropertyConstants.Rule.PROPOSITION_TREE_GROUP_ID,
-                    "error.rule.proposition.simple.hasChildren", proposition.getDescription());
-            result &= false; // simple prop should not have compound components
         }
 
         return result;
@@ -696,6 +709,10 @@ public class AgendaEditorController extends MaintenanceDocumentController {
         } else {
             form.getActionParameters().put(UifParameters.NAVIGATE_TO_PAGE_ID, "AgendaEditorView-EditRule-Page");
         }
+
+        // apply deleted item IDs
+        agendaEditor.applyDeletedPropositionIdsFromRule();
+
         return super.navigate(form, result, request, response);
     }
 
@@ -851,6 +868,7 @@ public class AgendaEditorController extends MaintenanceDocumentController {
             if (bogusRootNode != null) {
                 // clean up special case with bogus root node
                 agendaEditor.getAgenda().setFirstItemId(bogusRootNode.getWhenTrueId());
+                agendaEditor.getAgenda().setFirstItem(bogusRootNode.getWhenTrue());
                 ruleEditorMessage.append(" to ").append(getFirstAgendaItem(agendaEditor.getAgenda()).getRule().getName()).append(" When TRUE group");
             } else {
                 ruleEditorMessage.append(" within its sibling group, above " + olderSibling.getRule().getName());
@@ -952,6 +970,7 @@ public class AgendaEditorController extends MaintenanceDocumentController {
             if (bogusRootNode != null) {
                 // clean up special case with bogus root node
                 agendaEditor.getAgenda().setFirstItemId(bogusRootNode.getWhenFalseId());
+                agendaEditor.getAgenda().setFirstItem(bogusRootNode.getWhenFalse());
             }
             ruleEditorMessage.append("Moved ").append(node.getRule().getName()).append(" down ");
             ruleEditorMessage.append(" within its sibling group, below ").append(youngerSibling.getRule().getName());
@@ -1071,6 +1090,7 @@ public class AgendaEditorController extends MaintenanceDocumentController {
         if (bogusRootNode != null) {
             // clean up special case with bogus root node
             agendaEditor.getAgenda().setFirstItemId(bogusRootNode.getWhenFalseId());
+            agendaEditor.getAgenda().setFirstItem(bogusRootNode.getWhenFalse());
             ruleEditorMessage.append(getFirstAgendaItem(agendaEditor.getAgenda()).getRule().getName()).append(" When TRUE group");
         }
         agendaEditor.setRuleEditorMessage(ruleEditorMessage.toString());
@@ -1317,6 +1337,7 @@ public class AgendaEditorController extends MaintenanceDocumentController {
             // need to handle the first item here, our recursive method won't handle it.
             if (agendaItemSelected.equals(firstItem.getId())) {
                 agendaEditor.getAgenda().setFirstItemId(firstItem.getAlwaysId());
+                agendaEditor.getAgenda().setFirstItem(firstItem.getAlways());
             } else {
                 deleteAgendaItem(firstItem, agendaItemSelected);
             }
@@ -1423,6 +1444,7 @@ public class AgendaEditorController extends MaintenanceDocumentController {
                 // remove node
                 if (orgRefNode == null) {
                     agendaEditor.getAgenda().setFirstItemId(node.getAlwaysId());
+                    agendaEditor.getAgenda().setFirstItem(node.getAlways());
                 } else {
                     // determine if true, false or always
                     // do appropriate operation
@@ -2282,7 +2304,9 @@ public class AgendaEditorController extends MaintenanceDocumentController {
             }
         }
 
+        agendaEditor.getDeletedPropositionIdsFromRule().add(selectedPropId);
         agendaEditor.getAgendaItemLine().getRule().refreshPropositionTree(false);
+
         return getUIFModelAndView(form);
     }
 

--- a/rice-middleware/krms/impl/src/test/groovy/org/kuali/rice/krms/impl/repository/AgendaBoServiceImplTest.groovy
+++ b/rice-middleware/krms/impl/src/test/groovy/org/kuali/rice/krms/impl/repository/AgendaBoServiceImplTest.groovy
@@ -14,19 +14,16 @@
  * limitations under the License.
  */
 package org.kuali.rice.krms.impl.repository
-
 import groovy.mock.interceptor.MockFor
 import org.junit.Assert
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
-import org.kuali.rice.krad.bo.PersistableBusinessObject
 import org.kuali.rice.krad.data.DataObjectService
 import org.kuali.rice.krms.api.repository.agenda.AgendaDefinition
 import org.kuali.rice.krms.api.repository.type.KrmsAttributeDefinition
-import org.kuali.rice.krms.framework.engine.Agenda
 
-import static org.kuali.rice.krms.impl.repository.RepositoryTestUtils.*;
+import static org.kuali.rice.krms.impl.repository.RepositoryTestUtils.buildQueryResults;
 
 class AgendaBoServiceImplTest {
 
@@ -341,28 +338,30 @@ class AgendaBoServiceImplTest {
 
   @Test
   void test_updateAgenda_success() {
-		mockDataObjectService.demand.find(1..1) { clazz, id -> TEST_AGENDA_BO }
-		mockDataObjectService.demand.deleteMatching(1) { clazz, map -> }
-		mockDataObjectService.demand.save { bo, po ->
-            ((AgendaBo)bo).setId("1");
-            return bo;
+        mockDataObjectService.demand.find(1..1) { clazz, id -> TEST_AGENDA_BO }
+        mockDataObjectService.demand.find(1..1) { clazz, id -> TEST_AGENDA_BO.getFirstItem() }
+        mockDataObjectService.demand.deleteMatching(1) { clazz, map -> }
+        mockDataObjectService.demand.save { bo, po ->
+          ((AgendaBo)bo).setId("1");
+          return bo;
         }
 
         mockAttributeDefinitionService.demand.findAttributeDefinitionsByType { String typeId ->
-            [KrmsAttributeDefinition.Builder.create(ADB1).build(), KrmsAttributeDefinition.Builder.create(ADB2).build()] };
+          [KrmsAttributeDefinition.Builder.create(ADB1).build(), KrmsAttributeDefinition.Builder.create(ADB2).build()] };
         KrmsAttributeDefinitionService attributeDefinitionService = mockAttributeDefinitionService.proxyDelegateInstance();
 
-		DataObjectService dataObjectService = mockDataObjectService.proxyDelegateInstance()
-		AgendaBoService service = new AgendaBoServiceImpl()
-		service.setDataObjectService(dataObjectService)
+        DataObjectService dataObjectService = mockDataObjectService.proxyDelegateInstance()
+        AgendaBoService service = new AgendaBoServiceImpl()
+        service.setDataObjectService(dataObjectService)
         service.setAttributeDefinitionService(attributeDefinitionService);
 
-		KrmsAttributeDefinitionService kads = new KrmsAttributeDefinitionServiceImpl();
-		kads.setDataObjectService(dataObjectService)
-		KrmsRepositoryServiceLocator.setKrmsAttributeDefinitionService(kads)
-		
-		service.updateAgenda(TEST_EXISTING_AGENDA_DEF)
-		mockDataObjectService.verify(dataObjectService)
+        KrmsAttributeDefinitionService kads = new KrmsAttributeDefinitionServiceImpl();
+        kads.setDataObjectService(dataObjectService)
+        KrmsRepositoryServiceLocator.setKrmsAttributeDefinitionService(kads)
+
+        service.updateAgenda(TEST_EXISTING_AGENDA_DEF)
+      
+        mockDataObjectService.verify(dataObjectService)
   }
 
 }

--- a/rice-middleware/krms/impl/src/test/java/org/kuali/rice/krms/impl/repository/AgendaBoTest.java
+++ b/rice-middleware/krms/impl/src/test/java/org/kuali/rice/krms/impl/repository/AgendaBoTest.java
@@ -93,6 +93,7 @@ public class AgendaBoTest {
         agendaItemBo02.setAlways(agendaItemBo03);
 
         agendaBo.setFirstItemId(agendaItemBo00.getId());
+        agendaBo.setFirstItem(agendaItemBo00);
 
         agendaBo.setItems(agendaItemBos);
 


### PR DESCRIPTION
This includes the following commits from Rice 2.5:

**KULRICE-12733:** Child propositions (and rules) not updated on save
https://github.com/kuali/rice/commit/2b65cf8d190de49d3a0888faa1a5d94718f56d57
https://github.com/kuali/rice/commit/d6d3dee161316e4a191b58157c84b8bc635797f3
https://github.com/kuali/rice/commit/7396074007cb9fa9ca78add8d8ad403841599c63

**KULRICE-14015:** Agenda Items are orphaned upon Agenda save
https://github.com/kuali/rice/commit/f61925f28eb9ba0f82f2a4be0e2671b51a8d7feb