### PR TITLE
EN-4606: Modified the source on an image to make it use HTTPS

### DIFF
--- a/rice-middleware/web/src/main/webapp/acknowledgments.jsp
+++ b/rice-middleware/web/src/main/webapp/acknowledgments.jsp
@@ -35,7 +35,7 @@
 <BR/>
 <h3><a name="Acknowledgements-"></a><font color="maroon">Acknowledgments</font></h3>
 
-<p><img src="http://opensource.org/trademarks/osi-certified/web/osi-certified-60x50.png" align="right" border="0" /><br/>
+<p><img src="https://opensource.org/trademarks/osi-certified/web/osi-certified-60x50.png" align="right" border="0" /><br/>
 Copyright 2005-2014 The Kuali Foundation. All rights reserved. Kuali is licensed for use pursuant to the <a href="http://www.opensource.org/licenses/ecl2.php">Educational Community License, Version 2.0</a>. Portions of Kuali are copyrighted by other parties, including the parties listed below, and you should see the licenses directory for complete copyright and licensing information. Questions about licensing should be directed to <span class="nobr"><a href="mailto:licensing@kuali.org" title="Send mail to licensing@kuali.org" rel="nofollow">licensing@kuali.org</a>.</span></p>
 
 <h3><a name="LicensingandAcknowledgments-ThirdPartyContributions"></a>Third Party Contributions</h3>


### PR DESCRIPTION
There is an image included on the acknowledgements page in Rice which
only uses HTTP.  This modifies it to always use HTTPS (which it
redirects to by default) to avoid a mixed content security warning