### PR TITLE
ESIMW-604 - allow non file attachments

### DIFF
--- a/rice-middleware/impl/src/main/java/org/kuali/rice/kew/notes/service/AttachmentService.java
+++ b/rice-middleware/impl/src/main/java/org/kuali/rice/kew/notes/service/AttachmentService.java
@@ -18,6 +18,7 @@ package org.kuali.rice.kew.notes.service;
 import java.io.File;
 
 import org.kuali.rice.kew.notes.Attachment;
+import org.springframework.core.io.Resource;
 
 /**
  * A service providing access for attachments.
@@ -30,6 +31,7 @@ public interface AttachmentService {
 
 	public void persistAttachedFileAndSetAttachmentBusinessObjectValue(Attachment attachment) throws Exception;
 	public File findAttachedFile(Attachment attachment) throws Exception;
+	public Resource findAttachedResource(Attachment attachment);
 	public void deleteAttachedFile(Attachment attachment) throws Exception;
 	
 }

--- a/rice-middleware/impl/src/main/java/org/kuali/rice/kew/notes/service/NoteService.java
+++ b/rice-middleware/impl/src/main/java/org/kuali/rice/kew/notes/service/NoteService.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.kuali.rice.kew.notes.Attachment;
 import org.kuali.rice.kew.notes.Note;
+import org.springframework.core.io.Resource;
 
 /**
  * A service which handles data access for notes and attachments.
@@ -37,6 +38,7 @@ public interface NoteService {
     public void deleteNote(Note note);
     public void deleteAttachment(Attachment attachment);
     public File findAttachmentFile(Attachment attachment);
+    public Resource findAttachmentResource(Attachment attachment);
     public Attachment findAttachment(String attachmentId);
     
 }

--- a/rice-middleware/impl/src/main/java/org/kuali/rice/kew/notes/service/impl/AttachmentServiceImpl.java
+++ b/rice-middleware/impl/src/main/java/org/kuali/rice/kew/notes/service/impl/AttachmentServiceImpl.java
@@ -15,14 +15,15 @@
  */
 package org.kuali.rice.kew.notes.service.impl;
 
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.util.logging.Logger;
-
 import org.kuali.rice.kew.notes.Attachment;
 import org.kuali.rice.kew.notes.service.AttachmentService;
 import org.kuali.rice.kew.service.KEWServiceLocator;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
 
 
 /**
@@ -72,7 +73,11 @@ public class AttachmentServiceImpl implements AttachmentService {
 	public File findAttachedFile(Attachment attachment) throws Exception {
 		return new File(attachment.getFileLoc());
 	}
-	
+
+	public Resource findAttachedResource(Attachment attachment) {
+		return new FileSystemResource(new File(attachment.getFileLoc()));
+	}
+
 	public void deleteAttachedFile(Attachment attachment) throws Exception {
 		File file = new File(attachment.getFileLoc());
 		if (! file.delete()) {

--- a/rice-middleware/impl/src/main/java/org/kuali/rice/kew/notes/service/impl/NoteServiceImpl.java
+++ b/rice-middleware/impl/src/main/java/org/kuali/rice/kew/notes/service/impl/NoteServiceImpl.java
@@ -26,6 +26,7 @@ import org.kuali.rice.kew.notes.service.AttachmentService;
 import org.kuali.rice.kew.notes.service.NoteService;
 import org.kuali.rice.krad.data.DataObjectService;
 import org.springframework.beans.factory.annotation.Required;
+import org.springframework.core.io.Resource;
 
 public class NoteServiceImpl implements NoteService {
 
@@ -91,6 +92,10 @@ public class NoteServiceImpl implements NoteService {
 			throw new RuntimeException(e);
 		}
 
+	}
+
+	public Resource findAttachmentResource(Attachment attachment) {
+		return attachmentService.findAttachedResource(attachment);
 	}
 
 	public Attachment findAttachment(String attachmentId) {

--- a/rice-middleware/impl/src/main/java/org/kuali/rice/kew/notes/web/AttachmentServlet.java
+++ b/rice-middleware/impl/src/main/java/org/kuali/rice/kew/notes/web/AttachmentServlet.java
@@ -17,15 +17,17 @@ package org.kuali.rice.kew.notes.web;
 
 import org.apache.log4j.Logger;
 import org.kuali.rice.coreservice.framework.CoreFrameworkServiceLocator;
+import org.kuali.rice.kew.api.KewApiConstants;
 import org.kuali.rice.kew.api.WorkflowRuntimeException;
 import org.kuali.rice.kew.doctype.SecuritySession;
 import org.kuali.rice.kew.notes.Attachment;
 import org.kuali.rice.kew.notes.service.NoteService;
 import org.kuali.rice.kew.routeheader.DocumentRouteHeaderValue;
 import org.kuali.rice.kew.service.KEWServiceLocator;
-import org.kuali.rice.kew.api.KewApiConstants;
 import org.kuali.rice.krad.UserSession;
+import org.kuali.rice.krad.util.GlobalVariables;
 import org.kuali.rice.krad.util.KRADConstants;
+import org.springframework.core.io.Resource;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -33,9 +35,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 
 
@@ -43,92 +44,102 @@ import java.io.OutputStream;
 
 /**
  * A servlet which can be used to retrieve attachments from Notes.
- * 
+ *
  * @author Kuali Rice Team (rice.collab@kuali.org)
  */
 public class AttachmentServlet extends HttpServlet {
-	
-	private static final long serialVersionUID = -1918858512573502697L;
-	public static final String ATTACHMENT_ID_KEY = "attachmentId";
 
-	// TODO This should probably be put into KewApiConstants when contributed back
-	// to Rice 1.0.3
-	private static final Logger LOG = Logger.getLogger(AttachmentServlet.class);
-			
-	@Override
-	protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		String attachmentId = request.getParameter(ATTACHMENT_ID_KEY);
-		if (attachmentId == null) {
-			throw new ServletException("No 'attachmentId' was specified.");
-		}
-		
-		boolean secureChecks = false;
-		String secureAttachmentsParam = null;
-		try {
-			secureAttachmentsParam = CoreFrameworkServiceLocator.getParameterService().getParameterValueAsString(KewApiConstants.KEW_NAMESPACE, "All", KewApiConstants.SECURE_ATTACHMENTS_PARAM);
-		} catch (Exception e) {
-			LOG.info("Attempted to retrieve parameter value, but could not. Defaulting to unsecured attachment retrieval. " + e.getMessage());
-		}
-		if (secureAttachmentsParam != null && secureAttachmentsParam.equals("Y")) {
-			secureChecks = true;
-		}
-		try {
-			UserSession userSession = (UserSession) request.getSession().getAttribute(KRADConstants.USER_SESSION_KEY);
-			if (userSession != null) {// If we can get a valid userSession object off the Http request...
-				
-				NoteService noteService = KEWServiceLocator.getNoteService(); 
-				Attachment attachment = noteService.findAttachment(attachmentId);
-				File file = noteService.findAttachmentFile(attachment);
-				
-				DocumentRouteHeaderValue routeHeader = KEWServiceLocator.getRouteHeaderService().getRouteHeader(noteService.getNoteByNoteId(attachment.getNoteId()).getDocumentId());
-				
-				if(!secureChecks || routeHeader != null){// If we can get a valid routeHeader based on the requested attachment ID
-					boolean authorized = KEWServiceLocator.getDocumentSecurityService().routeLogAuthorized(userSession.getPrincipalId(), routeHeader, new SecuritySession(userSession.getPrincipalId()));
+    private static final long serialVersionUID = -1918858512573502697L;
+    public static final String ATTACHMENT_ID_KEY = "attachmentId";
+
+    // TODO This should probably be put into KewApiConstants when contributed back
+    // to Rice 1.0.3
+    private static final Logger LOG = Logger.getLogger(AttachmentServlet.class);
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String attachmentId = request.getParameter(ATTACHMENT_ID_KEY);
+        if (attachmentId == null) {
+            throw new ServletException("No 'attachmentId' was specified.");
+        }
+
+        boolean secureChecks = false;
+        String secureAttachmentsParam = null;
+        try {
+            secureAttachmentsParam = CoreFrameworkServiceLocator.getParameterService().getParameterValueAsString(KewApiConstants.KEW_NAMESPACE, "All", KewApiConstants.SECURE_ATTACHMENTS_PARAM);
+        } catch (Exception e) {
+            LOG.info("Attempted to retrieve parameter value, but could not. Defaulting to unsecured attachment retrieval. " + e.getMessage());
+        }
+        if (secureAttachmentsParam != null && secureAttachmentsParam.equals("Y")) {
+            secureChecks = true;
+        }
+
+        UserSession userSession = (UserSession) request.getSession().getAttribute(KRADConstants.USER_SESSION_KEY);
+        if (userSession != null) {// If we can get a valid userSession object off the Http request...
+            try {
+                GlobalVariables.setUserSession(userSession);
+                NoteService noteService = KEWServiceLocator.getNoteService();
+
+                Attachment attachment = noteService.findAttachment(attachmentId);
+
+
+                Resource resource = noteService.findAttachmentResource(attachment);
+
+                DocumentRouteHeaderValue routeHeader = KEWServiceLocator.getRouteHeaderService().getRouteHeader(noteService.getNoteByNoteId(attachment.getNoteId()).getDocumentId());
+
+                if (!secureChecks || routeHeader != null) {// If we can get a valid routeHeader based on the requested attachment ID
+                    boolean authorized = KEWServiceLocator.getDocumentSecurityService().routeLogAuthorized(userSession.getPrincipalId(), routeHeader, new SecuritySession(userSession.getPrincipalId()));
                     boolean customAttributeAuthorized = false;
-                    if(routeHeader.getCustomNoteAttribute() != null){
-                        routeHeader.getCustomNoteAttribute().setUserSession(userSession);
-                        customAttributeAuthorized = routeHeader.getCustomNoteAttribute().isAuthorizedToRetrieveAttachments();
-                    }                    
-                    if(!secureChecks || (authorized && customAttributeAuthorized)){//If this user can see this document, they can get the attachment(s)						
-                    	response.setContentLength((int)file.length());
-						response.setContentType(attachment.getMimeType());
-						response.setHeader("Content-disposition", "attachment; filename=\"" + attachment.getFileName() + "\"");
-						FileInputStream attachmentFile = new FileInputStream(file);
-						BufferedInputStream inputStream = new BufferedInputStream(attachmentFile);
-						OutputStream outputStream = new BufferedOutputStream(response.getOutputStream());
+                    try {
+                        if (routeHeader.getCustomNoteAttribute() != null) {
+                            routeHeader.getCustomNoteAttribute().setUserSession(userSession);
+                            customAttributeAuthorized = routeHeader.getCustomNoteAttribute().isAuthorizedToRetrieveAttachments();
+                        }
+                    } catch (Exception e) {
+                        LOG.error("Problem retrieving requested attachmentId:" + attachmentId, e);
+                        throw new WorkflowRuntimeException(e);
+                    }
+                    if (!secureChecks || (authorized && customAttributeAuthorized)) {//If this user can see this document, they can get the attachment(s)
+                        // make sure we can successfully get an inputstream to the data before we start setting response headers
+                        InputStream data = resource.getInputStream();
+                        response.setContentLength((int) resource.contentLength());
+                        response.setContentType(attachment.getMimeType());
+                        response.setHeader("Content-disposition", "attachment; filename=\"" + attachment.getFileName() + "\"");
+                        BufferedInputStream inputStream = new BufferedInputStream(data);
+                        OutputStream outputStream = new BufferedOutputStream(response.getOutputStream());
 
-						try {
-							int c;
-							while ((c = inputStream.read()) != -1) {
-								outputStream.write(c);
-							}
-						} finally {
-							inputStream.close();
-						}
-						outputStream.close();
-					} else {// Throw a forbidden page back, they were not approved by DocumentSecurityService
-						LOG.error("Attempt to access attachmentId:"+ attachmentId + " from documentId:" + routeHeader.getDocumentId() + " from unauthorized user: " + userSession.getPrincipalId());
-						response.sendError(HttpServletResponse.SC_FORBIDDEN);
-						return;
-					}
-				} else {// Throw a not found, couldn't get a valid routeHeader
-					LOG.error("Caught Null Pointer trying to determine routeHeader for requested attachmentId:" + attachmentId);
-					response.sendError(HttpServletResponse.SC_NOT_FOUND);
-					return;
-				}
-			} else {// Throw a bad request, we couldn't find a valid user session
-				LOG.error("Attempt to access attachmentId:" + attachmentId + " with invalid UserSession");
-				response.sendError(HttpServletResponse.SC_BAD_REQUEST);
-				return;
-			}
-		} catch (Exception e) {// Catch any error, log it. Send a not found, and throw up the exception.
-			LOG.error("Problem retrieving requested attachmentId:" + attachmentId, e);
-			throw new WorkflowRuntimeException(e);
-		}
-	}
-	@Override
-	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		doPost(request, response);
-	}	
-	
+                        try {
+                            int c;
+                            while ((c = inputStream.read()) != -1) {
+                                outputStream.write(c);
+                            }
+                        } finally {
+                            inputStream.close();
+                        }
+                        outputStream.close();
+                    } else {// Throw a forbidden page back, they were not approved by DocumentSecurityService
+                        LOG.error("Attempt to access attachmentId:" + attachmentId + " from documentId:" + routeHeader.getDocumentId() + " from unauthorized user: " + userSession.getPrincipalId());
+                        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+                        return;
+                    }
+                } else {// Throw a not found, couldn't get a valid routeHeader
+                    LOG.error("Caught Null Pointer trying to determine routeHeader for requested attachmentId:" + attachmentId);
+                    response.sendError(HttpServletResponse.SC_NOT_FOUND);
+                    return;
+                }
+            } finally {
+                GlobalVariables.setUserSession(null);
+            }
+        } else {// Throw a bad request, we couldn't find a valid user session
+            LOG.error("Attempt to access attachmentId:" + attachmentId + " with invalid UserSession");
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+    }
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        doPost(request, response);
+    }
+
 }


### PR DESCRIPTION
Work to allow for attachments to be loaded as Spring Resource objects instead of just files, in larger support of the shared file-system to S3 migration efforts at IU

FYI: AttachmentServlet whitespace was a mess, so apologies for the re-formatting diff was just trying to inject some sanity into it.