### PR TITLE
ESIMW-1249: Dependency cleanup

### DIFF
--- a/db/xml/pom.xml
+++ b/db/xml/pom.xml
@@ -184,6 +184,10 @@
   </build>
   <dependencies>
     <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.kuali.common</groupId>
       <artifactId>kuali-util</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2038,6 +2038,16 @@
         <groupId>org.apache.wss4j</groupId>
         <artifactId>wss4j-policy</artifactId>
         <version>${wss4j.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.xml.stream</groupId>
+            <artifactId>stax-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.codehaus.woodstox</groupId>
+            <artifactId>woodstox-core-asl</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.wss4j</groupId>
@@ -2051,6 +2061,18 @@
           <exclusion>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.opensaml</groupId>
+            <artifactId>opensaml-saml-impl</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.opensaml</groupId>
+            <artifactId>opensaml-xacml-impl</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.opensaml</groupId>
+            <artifactId>opensaml-xacml-saml-impl</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/rice-framework/krad-it/pom.xml
+++ b/rice-framework/krad-it/pom.xml
@@ -153,6 +153,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>mysql</groupId>
       <artifactId>${mysql.jdbc.artifactId}</artifactId>
     </dependency>

--- a/rice-middleware/it/kcb/pom.xml
+++ b/rice-middleware/it/kcb/pom.xml
@@ -32,6 +32,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>rice-impl</artifactId>
       <version>${project.version}</version>

--- a/rice-middleware/it/kns/pom.xml
+++ b/rice-middleware/it/kns/pom.xml
@@ -34,6 +34,7 @@
   </properties>
 
   <dependencies>
+
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>rice-impl</artifactId>
@@ -143,6 +144,11 @@
       <type>test-jar</type>
     </dependency>
 
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>displaytag</groupId>
       <artifactId>displaytag</artifactId>

--- a/rice-middleware/it/vc/pom.xml
+++ b/rice-middleware/it/vc/pom.xml
@@ -54,6 +54,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <exclusions>

--- a/rice-middleware/ksb/client-impl/pom.xml
+++ b/rice-middleware/ksb/client-impl/pom.xml
@@ -182,10 +182,6 @@
       <artifactId>cxf-rt-ws-security</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.cxf</groupId>
-      <artifactId>cxf-rt-transports-http-jetty</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-httpclient</groupId>
       <artifactId>commons-httpclient</artifactId>
     </dependency>


### PR DESCRIPTION
* Remove OpenSAML JARs, old stax-api and woodstox implementation from WSS4J
* Remove CXF Jetty runtime from KSB client implementation
* Add servlet-api dependency to several modules which should have had direct dependencies on it but were inheriting it from the CXF Jetty runtime