### PR TITLE
ESIMW-1373 - Remove Old Mail Dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
     <junit.version>4.11</junit.version>
     <kuali-mvn.version>1.0.2</kuali-mvn.version>
     <log4j.version>1.2.16</log4j.version>
-    <mail.version>1.4.4</mail.version>
+    <mail.version>1.6.1</mail.version>
     <mockito.version>2.23.0</mockito.version>
     <powermock.version>2.0.0-RC.4</powermock.version>
     <persistence.version>1.0.1.Final</persistence.version>
@@ -1682,8 +1682,8 @@
       </dependency>
 
       <dependency>
-        <groupId>javax.mail</groupId>
-        <artifactId>mail</artifactId>
+        <groupId>com.sun.mail</groupId>
+        <artifactId>javax.mail</artifactId>
         <version>${mail.version}</version>
         <exclusions>
           <exclusion>

--- a/rice-middleware/core-service/impl/pom.xml
+++ b/rice-middleware/core-service/impl/pom.xml
@@ -164,8 +164,8 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.mail</groupId>
-      <artifactId>mail</artifactId>
+      <groupId>com.sun.mail</groupId>
+      <artifactId>javax.mail</artifactId>
     </dependency>
 
     <dependency>

--- a/rice-middleware/core/api/pom.xml
+++ b/rice-middleware/core/api/pom.xml
@@ -80,8 +80,8 @@
       <artifactId>joda-time</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.mail</groupId>
-      <artifactId>mail</artifactId>
+      <groupId>com.sun.mail</groupId>
+      <artifactId>javax.mail</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/rice-middleware/core/impl/pom.xml
+++ b/rice-middleware/core/impl/pom.xml
@@ -73,8 +73,8 @@
       <artifactId>jsp-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.mail</groupId>
-      <artifactId>mail</artifactId>
+      <groupId>com.sun.mail</groupId>
+      <artifactId>javax.mail</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/rice-middleware/impl/pom.xml
+++ b/rice-middleware/impl/pom.xml
@@ -246,8 +246,8 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.mail</groupId>
-      <artifactId>mail</artifactId>
+      <groupId>com.sun.mail</groupId>
+      <artifactId>javax.mail</artifactId>
     </dependency>
 
     <dependency>

--- a/rice-middleware/it/edl/pom.xml
+++ b/rice-middleware/it/edl/pom.xml
@@ -159,8 +159,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>javax.mail</groupId>
-      <artifactId>mail</artifactId>
+      <groupId>com.sun.mail</groupId>
+      <artifactId>javax.mail</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/rice-middleware/it/kew/pom.xml
+++ b/rice-middleware/it/kew/pom.xml
@@ -201,8 +201,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>javax.mail</groupId>
-      <artifactId>mail</artifactId>
+      <groupId>com.sun.mail</groupId>
+      <artifactId>javax.mail</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Foundation Rice modules were bringing in an old javax.mail dependency which can cause classloader issues with the newer mail signing library

Co-Authored-By: James Bennett <jwbennet@gmail.com>
Co-Authored-By: Andy Hill <athill@users.noreply.github.com>