### PR TITLE
ESIMW-1383 - Fix keystore location string

### DIFF
--- a/rice-middleware/core/framework/src/main/java/org/kuali/rice/core/framework/config/property/AbstractBaseConfig.java
+++ b/rice-middleware/core/framework/src/main/java/org/kuali/rice/core/framework/config/property/AbstractBaseConfig.java
@@ -218,7 +218,7 @@ public abstract class AbstractBaseConfig implements org.kuali.rice.core.api.conf
 
     public String getKeystoreFile() throws IOException {
         String keyStoreFile = getProperty(org.kuali.rice.core.api.config.property.Config.KEYSTORE_FILE);
-        return new ClasspathOrFileResourceLoader().getResource(keyStoreFile).getURL().toString();
+        return new ClasspathOrFileResourceLoader().getResource(keyStoreFile).getURL().getFile();
     }
 
     public String getKeystorePassword() {


### PR DESCRIPTION
In the newer version of Spring, `getUrl` appends `file:` to file resources, which breaks the behavior of methods that call `AbstractBaseConfig.getKeystoreFile` as they expect the raw file path.