### PR TITLE
ESIMW-1249: Add more JAXB dependencies to spring-maven-plugin

### DIFF
--- a/db/sql/pom.xml
+++ b/db/sql/pom.xml
@@ -79,6 +79,11 @@
                 <artifactId>kuali-jdbc</artifactId>
                 <version>${kuali-jdbc.version}</version>
               </dependency>
+              <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>${jaxb-impl.version}</version>
+              </dependency>
             </dependencies>
           </plugin>
         </plugins>
@@ -134,6 +139,11 @@
             <groupId>org.kuali.common</groupId>
             <artifactId>kuali-deploy</artifactId>
             <version>${kuali-deploy.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>${jaxb-impl.version}</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/db/xml/pom.xml
+++ b/db/xml/pom.xml
@@ -106,6 +106,11 @@
                 <artifactId>rice-krms-impl</artifactId>
                 <version>${project.version}</version>
               </dependency>
+              <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>${jaxb-impl.version}</version>
+              </dependency>
             </dependencies>
           </plugin>
         </plugins>
@@ -177,6 +182,11 @@
             <groupId>org.kuali.common</groupId>
             <artifactId>kuali-deploy</artifactId>
             <version>${kuali-deploy.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>${jaxb-impl.version}</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -418,6 +418,11 @@
                 <artifactId>kuali-deploy</artifactId>
                 <version>${kuali-deploy.version}</version>
               </dependency>
+              <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>${jaxb-impl.version}</version>
+              </dependency>
             </dependencies>
           </plugin>
         </plugins>


### PR DESCRIPTION
This seemed to build fine except during a release so this explicitly adds the jaxb-runtime JARs to each execution of the spring-maven-plugin to avoid issues finding JAXB during a release.