### PR TITLE
ESIMW-1249 - Downgrade CXF

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
     <commons-pool.version>1.5.7</commons-pool.version>
     <commons-digester.version>2.0</commons-digester.version>
     <commons-validator.version>1.3.1</commons-validator.version>
-    <cxf.version>3.3.0</cxf.version>
+    <cxf.version>3.2.7</cxf.version>
     <jaxb-impl.version>2.3.1</jaxb-impl.version>
     <db-ojb.version>1.0.4-patch9</db-ojb.version>
     <displaytag.version>1.2</displaytag.version>


### PR DESCRIPTION
The newer version of CXF is built to support Java 11, but it brings in "banned" dependencies. The previous version seemed to be working well enough, so we should do a deeper dive on upgrading this dependency and its implications